### PR TITLE
input_sizeとtest_input_sizeを使う運用に

### DIFF
--- a/classification/config/_base_/augmentation/basic.yaml
+++ b/classification/config/_base_/augmentation/basic.yaml
@@ -22,6 +22,7 @@ augmentation:
   val:
     ops:
       - type: Resize
+      - type: CenterCrop
       - type: Normalize
         mean: [0.485, 0.456, 0.406]
         std: [0.229, 0.224, 0.225]

--- a/classification/config/_base_/augmentation/basic.yaml
+++ b/classification/config/_base_/augmentation/basic.yaml
@@ -22,7 +22,6 @@ augmentation:
   val:
     ops:
       - type: Resize
-      - type: CenterCrop
       - type: Normalize
         mean: [0.485, 0.456, 0.406]
         std: [0.229, 0.224, 0.225]

--- a/classification/config/_base_/augmentation/strong.yaml
+++ b/classification/config/_base_/augmentation/strong.yaml
@@ -31,6 +31,7 @@ augmentation:
   val:
     ops:
       - type: Resize
+      - type: CenterCrop
       - type: Normalize
         mean: [0.485, 0.456, 0.406]
         std: [0.229, 0.224, 0.225]

--- a/classification/config/_base_/model/convnext_base.yaml
+++ b/classification/config/_base_/model/convnext_base.yaml
@@ -5,4 +5,5 @@ model:
   pretrained: true
   drop_rate: 0.0
   drop_path_rate: 0.0
-  input_size: 288
+  input_size: 224
+  crop_pct: 0.875

--- a/classification/config/_base_/model/convnext_base.yaml
+++ b/classification/config/_base_/model/convnext_base.yaml
@@ -6,4 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 224
-  crop_pct: 0.875
+  test_input_size: 288

--- a/classification/config/_base_/model/efficientnet_b4.yaml
+++ b/classification/config/_base_/model/efficientnet_b4.yaml
@@ -5,4 +5,5 @@ model:
   pretrained: true
   drop_rate: 0.0
   drop_path_rate: 0.0
-  input_size: 384
+  input_size: 380
+  crop_pct: 0.922

--- a/classification/config/_base_/model/efficientnet_b4.yaml
+++ b/classification/config/_base_/model/efficientnet_b4.yaml
@@ -5,5 +5,5 @@ model:
   pretrained: true
   drop_rate: 0.0
   drop_path_rate: 0.0
-  input_size: 380
-  crop_pct: 0.922
+  input_size: 320
+  test_input_size: 384

--- a/classification/config/_base_/model/efficientnetv2_s.yaml
+++ b/classification/config/_base_/model/efficientnetv2_s.yaml
@@ -6,3 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 384
+  crop_pct: 1.0

--- a/classification/config/_base_/model/efficientnetv2_s.yaml
+++ b/classification/config/_base_/model/efficientnetv2_s.yaml
@@ -5,5 +5,5 @@ model:
   pretrained: true
   drop_rate: 0.0
   drop_path_rate: 0.0
-  input_size: 384
-  crop_pct: 1.0
+  input_size: 300
+  test_input_size: 384

--- a/classification/config/_base_/model/mobilenet_v2.yaml
+++ b/classification/config/_base_/model/mobilenet_v2.yaml
@@ -6,3 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 224
+  crop_pct: 0.875

--- a/classification/config/_base_/model/mobilenet_v2.yaml
+++ b/classification/config/_base_/model/mobilenet_v2.yaml
@@ -6,4 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 224
-  crop_pct: 0.875
+  test_input_size: 224

--- a/classification/config/_base_/model/swin_base.yaml
+++ b/classification/config/_base_/model/swin_base.yaml
@@ -6,4 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 224
-  crop_pct: 0.9
+  test_input_size: 224

--- a/classification/config/_base_/model/swin_base.yaml
+++ b/classification/config/_base_/model/swin_base.yaml
@@ -6,3 +6,4 @@ model:
   drop_rate: 0.0
   drop_path_rate: 0.0
   input_size: 224
+  crop_pct: 0.9

--- a/classification/scripts/run.sh
+++ b/classification/scripts/run.sh
@@ -5,10 +5,9 @@ uv run python src/train.py \
   --config config/experiments/food101_mobilenet_v2.yaml\
   --validate
 
-# uv run python src/train.py \
-#   --config config/experiments/food101_efficientnet_b4.yaml\
-#   --validate
+uv run python src/train.py \
+  --config config/experiments/food101_efficientnet_b4.yaml\
+  --validate
 
-# uv run python src/validate.py \
-#  --config config/experiments/food101_efficientnet_b0.yaml\
-#  --run-id de3b313b2f3640e4a7d6adf7c873cbae
+# uv run python src/export_onnx.py \
+#   --run-id 8b632d114a2a4379a36189f74d2f8de6

--- a/classification/src/builders/augmentation.py
+++ b/classification/src/builders/augmentation.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 import albumentations as A
@@ -14,14 +15,17 @@ from config import (
 def build_transforms(
     config: dict[str, Any],
     model_config: dict[str, Any] | None = None,
+    is_train: bool = True,
 ) -> A.Compose:
     """YAML設定からalbumentationsパイプラインを構築する.
 
     Args:
         config: ops配列を含む辞書
             例: {"ops": [{"type": "Resize", "height": 256, "width": 256}, ...]}
-        model_config: モデル設定辞書。input_sizeを含む場合、
+        model_config: モデル設定辞書。input_sizeとcrop_pctを含む場合、
             augmentationのサイズを自動調整する。
+        is_train: 訓練用かどうか。Falseの場合、valのResize/CenterCropサイズを
+            crop_pctに基づいて計算する。
 
     Returns:
         albumentations.Compose オブジェクト
@@ -37,15 +41,22 @@ def build_transforms(
     transforms: list[A.BasicTransform | BaseCompose] = []
 
     input_size: int | None = None
+    crop_pct: float = 0.875
+    resize_size: int | None = None
 
     if model_config:
-        input_size = model_config["input_size"]
+        input_size = model_config.get("input_size")
+        crop_pct = model_config.get("crop_pct", 0.875)
+        if input_size:
+            resize_size = int(math.ceil(input_size / crop_pct))
 
     for i, op_config in enumerate(transform_cfg.ops):
         try:
             transform = _build_single_transform(
                 op_config,
                 input_size=input_size,
+                resize_size=resize_size,
+                is_train=is_train,
             )
             transforms.append(transform)
         except ConfigValidationError:
@@ -96,16 +107,27 @@ def _apply_size_defaults(
     op_type: str,
     op_args: dict[str, Any],
     input_size: int | None,
+    resize_size: int | None,
+    is_train: bool,
 ) -> dict[str, Any]:
     """サイズ関連のデフォルト値を適用する."""
     if "height" in op_args and "width" in op_args:
         return op_args
 
-    if op_type in ("RandomResizedCrop", "CenterCrop", "Resize"):
+    if op_type in ("RandomResizedCrop", "CenterCrop"):
         if input_size is None:
             _raise_size_error(op_type, op_args)
         op_args["height"] = input_size
         op_args["width"] = input_size
+    elif op_type == "Resize":
+        if not is_train and resize_size is not None:
+            op_args["height"] = resize_size
+            op_args["width"] = resize_size
+        elif input_size is not None:
+            op_args["height"] = input_size
+            op_args["width"] = input_size
+        else:
+            _raise_size_error(op_type, op_args)
 
     return op_args
 
@@ -113,12 +135,16 @@ def _apply_size_defaults(
 def _build_single_transform(
     op_config: TransformOpConfig,
     input_size: int | None = None,
+    resize_size: int | None = None,
+    is_train: bool = True,
 ) -> A.BasicTransform:
     """単一のトランスフォームを構築する.
 
     Args:
         op_config: バリデーション済みのTransformOpConfig
         input_size: モデルの入力サイズ（height/widthが未指定の場合に使用）
+        resize_size: valのResizeサイズ（input_size / crop_pctで計算）
+        is_train: 訓練用かどうか
 
     Returns:
         albumentationsトランスフォームオブジェクト
@@ -129,7 +155,7 @@ def _build_single_transform(
     op_type = op_config.type
     op_args = {k: v for k, v in op_config.model_dump().items() if k != "type"}
 
-    op_args = _apply_size_defaults(op_type, op_args, input_size)
+    op_args = _apply_size_defaults(op_type, op_args, input_size, resize_size, is_train)
 
     if op_type == "RandomResizedCrop" and "height" in op_args and "width" in op_args:
         op_args["size"] = (op_args.pop("height"), op_args.pop("width"))

--- a/classification/src/data/datamodule.py
+++ b/classification/src/data/datamodule.py
@@ -55,11 +55,13 @@ class ClassificationDataModule(L.LightningDataModule):
             self.train_transform = build_transforms(
                 self.aug_config["train"],
                 model_config=self.model_config,
+                is_train=True,
             )
         if "val" in self.aug_config:
             self.val_transform = build_transforms(
                 self.aug_config["val"],
                 model_config=self.model_config,
+                is_train=False,
             )
 
         self.train_dataset: ImageFolderDataset | None = None

--- a/classification/src/export_onnx.py
+++ b/classification/src/export_onnx.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 import json
+import math
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -263,7 +264,11 @@ def export_onnx(
     )
 
     input_size = config["model"]["input_size"]
+    crop_pct = config["model"].get("crop_pct", 0.875)
+    resize_size = int(math.ceil(input_size / crop_pct))
     logger.info(f"Input size: {input_size}x{input_size}")
+    logger.info(f"Crop percentage: {crop_pct}")
+    logger.info(f"Validation resize size: {resize_size}x{resize_size}")
 
     output_file = Path(output_path) if output_path else exp_dir / f"{exp_name}.onnx"
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -274,7 +279,7 @@ def export_onnx(
     model.eval()
     model = model.to(torch.device("cpu"))
 
-    dummy_input = torch.randn(1, 3, input_size, input_size)
+    dummy_input = torch.randn(1, 3, resize_size, resize_size)
     logger.info(f"Dummy input shape: {dummy_input.shape}")
 
     dynamic_axes = (

--- a/classification/src/export_onnx.py
+++ b/classification/src/export_onnx.py
@@ -1,7 +1,6 @@
 import argparse
 import datetime
 import json
-import math
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -263,13 +262,6 @@ def export_onnx(
         checkpoint, run_id, base_output_dir, exp_name
     )
 
-    input_size = config["model"]["input_size"]
-    crop_pct = config["model"].get("crop_pct", 0.875)
-    resize_size = int(math.ceil(input_size / crop_pct))
-    logger.info(f"Input size: {input_size}x{input_size}")
-    logger.info(f"Crop percentage: {crop_pct}")
-    logger.info(f"Validation resize size: {resize_size}x{resize_size}")
-
     output_file = Path(output_path) if output_path else exp_dir / f"{exp_name}.onnx"
     output_file.parent.mkdir(parents=True, exist_ok=True)
     logger.info(f"Output path: {output_file}")
@@ -279,7 +271,12 @@ def export_onnx(
     model.eval()
     model = model.to(torch.device("cpu"))
 
-    dummy_input = torch.randn(1, 3, resize_size, resize_size)
+    if "test_input_size" not in config.get("model", {}):
+        raise ValueError(
+            "test_input_sizeは必須です。config.model.test_input_sizeを設定してください。"
+        )
+    test_input_size = int(config["model"]["test_input_size"])
+    dummy_input = torch.randn(1, 3, test_input_size, test_input_size)
     logger.info(f"Dummy input shape: {dummy_input.shape}")
 
     dynamic_axes = (

--- a/classification/tests/test_augmentation.py
+++ b/classification/tests/test_augmentation.py
@@ -175,46 +175,46 @@ class TestModelConfigSizeOverride:
     """model_configからサイズを自動設定するテスト."""
 
     def test_random_resized_crop_size_from_model_config(self) -> None:
-        """RandomResizedCropでheight/width未指定時にmodel_configから取得されることを確認."""
+        """RandomResizedCropでheight/width未指定時に学習時はinput_sizeが使用されることを確認."""
         config = {
             "ops": [
                 {"type": "RandomResizedCrop", "scale": [0.08, 1.0], "ratio": [0.75, 1.333]},
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380, "crop_pct": 0.922}
+        model_config = {"input_size": 380, "test_input_size": 413}
         transform = build_transforms(config, model_config=model_config, is_train=True)
 
         assert isinstance(transform, A.Compose)
         assert isinstance(transform.transforms[0], A.RandomResizedCrop)
+        # 学習時はinput_sizeが使われる
         assert transform.transforms[0].size == (380, 380)
 
     def test_center_crop_size_from_model_config(self) -> None:
-        """CenterCropでheight/width未指定時にmodel_configから取得されることを確認."""
+        """CenterCropでheight/width未指定時に検証時はtest_input_sizeが使用されることを確認."""
         config = {
             "ops": [
                 {"type": "CenterCrop"},
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380, "crop_pct": 0.922}
+        model_config = {"input_size": 380, "test_input_size": 413}
         transform = build_transforms(config, model_config=model_config, is_train=False)
 
         assert isinstance(transform, A.Compose)
         assert isinstance(transform.transforms[0], A.CenterCrop)
-        assert transform.transforms[0].height == 380
-        assert transform.transforms[0].width == 380
+        assert transform.transforms[0].height == 413
+        assert transform.transforms[0].width == 413
 
     def test_resize_size_from_model_config_val(self) -> None:
-        """Resizeでheight/width未指定時にcrop_pctから計算されたサイズが使用されることを確認."""
+        """Resizeでheight/width未指定時にtest_input_sizeが使用されることを確認."""
         config = {
             "ops": [
                 {"type": "Resize"},
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380, "crop_pct": 0.922}
-        # resize_size = ceil(380 / 0.922) = 413
+        model_config = {"input_size": 380, "test_input_size": 413}
         transform = build_transforms(config, model_config=model_config, is_train=False)
 
         assert isinstance(transform, A.Compose)
@@ -232,14 +232,15 @@ class TestModelConfigSizeOverride:
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 224, "crop_pct": 0.875}
+        model_config = {"input_size": 224, "test_input_size": 256}
         transform = build_transforms(config, model_config=model_config, is_train=False)
 
         dummy_image = np.random.randint(0, 256, (300, 300, 3), dtype=np.uint8)
         result = transform(image=dummy_image)
 
         assert "image" in result
-        assert result["image"].shape == (3, 224, 224)
+        # 検証時はtest_input_sizeが使われるため、ResizeとCenterCropの両方が256になる
+        assert result["image"].shape == (3, 256, 256)
 
 
 class TestErrorHandling:
@@ -273,6 +274,21 @@ class TestErrorHandling:
             build_transforms(config)
 
         assert "height/widthが未指定" in str(exc_info.value)
+
+    def test_missing_test_input_size_for_val_raises_error(self) -> None:
+        """val用のパイプラインでtest_input_sizeが未指定の場合にエラーが発生することを確認."""
+        config = {
+            "ops": [
+                {"type": "Resize"},
+                {"type": "ToTensorV2"},
+            ]
+        }
+        model_config = {"input_size": 224}
+
+        with pytest.raises(ConfigValidationError) as exc_info:
+            build_transforms(config, model_config=model_config, is_train=False)
+
+        assert "test_input_sizeは必須です" in str(exc_info.value)
 
 
 if __name__ == "__main__":

--- a/classification/tests/test_augmentation.py
+++ b/classification/tests/test_augmentation.py
@@ -182,8 +182,8 @@ class TestModelConfigSizeOverride:
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380}
-        transform = build_transforms(config, model_config=model_config)
+        model_config = {"input_size": 380, "crop_pct": 0.922}
+        transform = build_transforms(config, model_config=model_config, is_train=True)
 
         assert isinstance(transform, A.Compose)
         assert isinstance(transform.transforms[0], A.RandomResizedCrop)
@@ -197,8 +197,8 @@ class TestModelConfigSizeOverride:
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380}
-        transform = build_transforms(config, model_config=model_config)
+        model_config = {"input_size": 380, "crop_pct": 0.922}
+        transform = build_transforms(config, model_config=model_config, is_train=False)
 
         assert isinstance(transform, A.Compose)
         assert isinstance(transform.transforms[0], A.CenterCrop)
@@ -206,20 +206,21 @@ class TestModelConfigSizeOverride:
         assert transform.transforms[0].width == 380
 
     def test_resize_size_from_model_config_val(self) -> None:
-        """Resizeでheight/width未指定時にinput_sizeが使用されることを確認."""
+        """Resizeでheight/width未指定時にcrop_pctから計算されたサイズが使用されることを確認."""
         config = {
             "ops": [
                 {"type": "Resize"},
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 380}
-        transform = build_transforms(config, model_config=model_config)
+        model_config = {"input_size": 380, "crop_pct": 0.922}
+        # resize_size = ceil(380 / 0.922) = 413
+        transform = build_transforms(config, model_config=model_config, is_train=False)
 
         assert isinstance(transform, A.Compose)
         assert isinstance(transform.transforms[0], A.Resize)
-        assert transform.transforms[0].height == 380
-        assert transform.transforms[0].width == 380
+        assert transform.transforms[0].height == 413
+        assert transform.transforms[0].width == 413
 
     def test_full_val_pipeline_from_model_config(self) -> None:
         """val用の完全なパイプラインがmodel_configから正しく構築されることを確認."""
@@ -231,8 +232,8 @@ class TestModelConfigSizeOverride:
                 {"type": "ToTensorV2"},
             ]
         }
-        model_config = {"input_size": 224}
-        transform = build_transforms(config, model_config=model_config)
+        model_config = {"input_size": 224, "crop_pct": 0.875}
+        transform = build_transforms(config, model_config=model_config, is_train=False)
 
         dummy_image = np.random.randint(0, 256, (300, 300, 3), dtype=np.uint8)
         result = transform(image=dummy_image)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes separate sizes for training vs validation/inference.
> 
> - Add `test_input_size` to model configs and adjust some default `input_size` values
> - Update augmentation builder to accept `is_train` and auto-fill sizes from `input_size` (train) or `test_input_size` (val); raise when missing; add `CenterCrop` to val ops
> - Wire `is_train` usage in `ClassificationDataModule` for train/val transforms
> - Change ONNX export to require and use `model.test_input_size` for dummy input
> - Extend tests to cover new size behavior and error cases; enable EfficientNet-B4 run in `scripts/run.sh`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 796d34aa10123f4b2e9fe190f3f7748ad9e22249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->